### PR TITLE
readme.md: fix credit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ As mentioned the largest potential flaw found was an unlikely special case where
 
 ## Credits
 
-Credit for the original base formula comes from https://github.com/caskroom/homebrew-unofficial/blob/master/Casks/truecrypt.rb 
+Credit for the base formula comes from https://github.com/caskroom/homebrew-unofficial/blob/1f3022e6706e8ea45b98630c8d077a27d094075c/Casks/truecrypt.rb
 
 
 


### PR DESCRIPTION
Removed the word “original”, since it was not the first but a copy of the one in the main repo. The one in the main repo was added when casks still looked different and then suffered various changes so it’s harder to pinpoint one true “original”.

Also changed the link since I’ve decided to remove that one sooner (which means the current link is now pointing to a 404), since yours is better and recommended.