### PR TITLE
Remove deprecated gpg method

### DIFF
--- a/Casks/truecrypt.rb
+++ b/Casks/truecrypt.rb
@@ -5,8 +5,8 @@ cask 'truecrypt' do
   name 'truecrypt'
   url "https://github.com/DrWhax/truecrypt-archive/raw/master/TrueCrypt%20#{version}%20Mac%20OS%20X.dmg"
   # mirror "https://www.grc.com/misc/truecrypt/TrueCrypt%20#{version}%20Mac%20OS%20X.dmg"
-  gpg "#{url}.sig",
-      :key_id => 'c5f4bac4a7b22db8b8f85538e3ba73caf0d6b1e0'
+  #gpg "#{url}.sig",
+  #    :key_id => 'c5f4bac4a7b22db8b8f85538e3ba73caf0d6b1e0'
 
   homepage 'https://www.grc.com/misc/truecrypt/truecrypt.htm'
   #license :oss


### PR DESCRIPTION
Should fix Homebrew warning:

    Warning: Calling the `gpg` stanza is deprecated and will be disabled on 2018-12-31! There is no replacement.
    Please report this to the trinitronx/truecrypt tap:
      /usr/local/Homebrew/Library/Taps/trinitronx/homebrew-truecrypt/Casks/truecrypt.rb:8